### PR TITLE
Properly test for successfulness of request

### DIFF
--- a/freckle_client/client.py
+++ b/freckle_client/client.py
@@ -122,8 +122,7 @@ class FreckleClientV2(object):
             http_method, url, params=query_params, headers=headers,
             data=json.dumps(post_args))
 
-        if response.status_code != 200:
-            raise exceptions.FreckleClientException(
-                "Freckle API Response is not 200", response.text)
+        # if request failed (i.e. HTTP status code not 20x), raise appropriate error
+        response.raise_for_status()
 
         return response.json()


### PR DESCRIPTION
The previous test was too strict (testing if status_code == 200), because creating a time entry returns a status code 201, which should classify as 'success'. The new test uses the request module's test directly.
