### PR TITLE
Update tags params types with None

### DIFF
--- a/noko_client/schemas/tags_parameters.py
+++ b/noko_client/schemas/tags_parameters.py
@@ -9,10 +9,10 @@ from noko_client.schemas.validators import format_booleans
 
 
 class GetNokoTagsParameters(BaseModel):
-    """Process and validate parameters to make GET requests to the `entries` endpoint."""
+    """Process and validate parameters to make GET requests to the `tags` endpoint."""
 
-    name: str | None
-    billable: str | bool | None
+    name: str | None = None
+    billable: str | bool | None = None
 
     _format_booleans = field_validator("billable")(format_booleans)
 


### PR DESCRIPTION
Bug Fix:

Adding None = None to set a default value for the parameters. 